### PR TITLE
Skip over test runs that do not have a VSTest .trx file

### DIFF
--- a/src/AzDOTestResults.psd1
+++ b/src/AzDOTestResults.psd1
@@ -8,7 +8,7 @@
 RootModule = 'AzDOTestResults.psm1'
 
 # Version number of this module.
-ModuleVersion = '0.9.24'
+ModuleVersion = '0.9.25'
 
 # Supported PSEditions
 # CompatiblePSEditions = @()

--- a/tests/AzDOTestResults.tests.ps1
+++ b/tests/AzDOTestResults.tests.ps1
@@ -109,7 +109,27 @@ InModuleScope $moduleName {
 			It "Should identify non-TRX Content" {
 				$results.OtherContent.Length | Should Be 2
 			}
-		}
+        }
+        
+        Context "Given a request that contains a ZIP attachment" {
+            $samplesRoot = "$PSScriptRoot/samples/api"
+
+            $content = [string](Get-Content -Encoding UTF8 -ReadCount 0 -Path "$samplesRoot/NonVSTestRun.json")
+			$data = [PSCustomObject[]]((ConvertFrom-Json -InputObject $content).value)
+			$results = $data | Group-TestAttachmentList
+
+			It "Should not have null results" {
+				$results | Should Not Be $null
+			}
+
+			It "Should identify no TRX files" {
+				$results.TrxContent.Length | Should Be 0
+			}
+
+			It "Should identify non-TRX Content" {
+				$results.OtherContent.Length | Should Be 1
+			}
+        }
     }
 
     Describe "Get-TrxContent" {

--- a/tests/samples/api/NonVSTestRun.json
+++ b/tests/samples/api/NonVSTestRun.json
@@ -1,0 +1,13 @@
+{
+    "count": 1,
+    "value": [
+        {
+            "createdDate": "2020-06-16T05:57:58.627Z",
+            "url": "urn://org/project/_apis/test/Runs/1582120/Attachments/1",
+            "id": 1,
+            "fileName": "TestResults_1582120.zip",
+            "comment": "",
+            "size": 33700
+        }
+    ]
+}


### PR DESCRIPTION
In some scenarios it might occur that a build pipeline has multiple test runs and some of them might not have a VSTest .trx file. This PR changes the logic to skip over test runs that do not have a .trx file, and logs a warning if it encounters one. This allows the module to be used by folks who have this setup.

Fixes #1 